### PR TITLE
VB-2787: Merge VB-2787-2-4-5-order-attachement-error-filtering-template-argument-value-must-be-type-of-string-object-given to m2.4.4

### DIFF
--- a/Model/Template/Processor.php
+++ b/Model/Template/Processor.php
@@ -101,7 +101,7 @@ class Processor extends Template
         $textProcessor = $processor
             ->setStoreId($this->storeId)
             ->setDesignParams([0])
-            ->filter(__($area));
+            ->filter($area);
 
         return $textProcessor;
     }


### PR DESCRIPTION
Pull request created in: https://ttifc.atlassian.net/browse/VB-2787 by the Git Integration for Jira app.